### PR TITLE
Fix bug when `-redis-namespace` is not specified

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,12 +2,15 @@
 
 
 [[projects]]
+  digest = "1:bd285ec20a7450d2272631284de698f2d76e923a458fee90e99cc1db4b97708d"
   name = "github.com/DataDog/datadog-go"
   packages = ["statsd"]
+  pruneopts = "UT"
   revision = "e67964b4021ad3a334e748e8811eb3cd6becbc6e"
   version = "2.1.0"
 
 [[projects]]
+  digest = "1:6361fc2f37f6a779924d408a955883db8ae02255a26473517b03cd0a80f8cdd5"
   name = "github.com/go-redis/redis"
   packages = [
     ".",
@@ -17,14 +20,18 @@
     "internal/pool",
     "internal/proto",
     "internal/singleflight",
-    "internal/util"
+    "internal/util",
   ]
+  pruneopts = "UT"
   revision = "877867d2845fbaf86798befe410b6ceb6f5c29a3"
   version = "v6.10.2"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "48d3423879c10adc526d09a09ad234a44bdb3f5d5b27e3fceb265394a6454246"
+  input-imports = [
+    "github.com/DataDog/datadog-go/statsd",
+    "github.com/go-redis/redis",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/main.go
+++ b/main.go
@@ -7,12 +7,14 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-go/statsd"
+	"github.com/feedforce/datadog-sidekiq/slice"
 	"github.com/go-redis/redis"
 )
 
 const version = "v0.0.4"
 
 func makeRedisKey(keys []string) string {
+	keys = slice.Delete(keys, "")
 	return strings.Join(keys, ":")
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,27 @@
+package main
+
+import "testing"
+
+var testCases = []struct {
+	input  []string
+	output string
+}{
+	{[]string{""}, ""},
+	{[]string{"queues"}, "queues"},
+	{[]string{"", "queues"}, "queues"},
+	{[]string{"queues", ""}, "queues"},
+	{[]string{"namespace", "queues"}, "namespace:queues"},
+	{[]string{"namespace", "queue", "default"}, "namespace:queue:default"},
+	{[]string{"", "queue", ""}, "queue"},
+}
+
+func TestMakeRedisKey(t *testing.T) {
+	for _, testCase := range testCases {
+		expect := testCase.output
+		actual := makeRedisKey(testCase.input)
+
+		if expect != actual {
+			t.Errorf("Expect %q, Actual %q (input: %q)", expect, actual, testCase.input)
+		}
+	}
+}

--- a/slice/slice.go
+++ b/slice/slice.go
@@ -1,0 +1,13 @@
+package slice
+
+func Delete(slice []string, str string) []string {
+	var result []string
+
+	for _, v := range slice {
+		if v != str {
+			result = append(result, v)
+		}
+	}
+
+	return result
+}

--- a/slice/slice_test.go
+++ b/slice/slice_test.go
@@ -1,0 +1,31 @@
+package slice
+
+import (
+	"reflect"
+	"testing"
+)
+
+var testCases = []struct {
+	input1 []string
+	input2 string
+	output []string
+}{
+	{[]string{""}, "", nil},
+	{[]string{"queues"}, "", []string{"queues"}},
+	{[]string{"", "queues"}, "", []string{"queues"}},
+	{[]string{"queues", ""}, "", []string{"queues"}},
+	{[]string{"namespace", "queues"}, "", []string{"namespace", "queues"}},
+	{[]string{"namespace", "queue", "default"}, "", []string{"namespace", "queue", "default"}},
+	{[]string{"", "queue", ""}, "", []string{"queue"}},
+}
+
+func TestDelete(t *testing.T) {
+	for _, testCase := range testCases {
+		expect := testCase.output
+		actual := Delete(testCase.input1, testCase.input2)
+
+		if !reflect.DeepEqual(expect, actual) {
+			t.Errorf("Expect %q, Actual %q (input1: %q, input2: %q)", expect, actual, testCase.input1, testCase.input2)
+		}
+	}
+}


### PR DESCRIPTION
## Why?

In the code below, I found a bug that accessed the `:queues` key when`-redis-namespace` is not specified.

https://github.com/feedforce/datadog-sidekiq/blob/d0cb11a7c86310b732000c381287b16558fcc6f7/main.go#L22

## How?

I made it to access the correct key.

e.g. `queues`

## How to check operation

* [x] All tests is passed (execute `$ make test`)