### PR TITLE
Create Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+/.git
+/.gitignore
+Dockerfile
+LICENSE
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM golang:1.9-alpine as builder
+
+ENV PROJECT_PATH="/go/src/github.com/feedforce/datadog-sidekiq"
+
+RUN apk add --update \
+        ca-certificates \
+        git \
+        curl && \
+    curl -L https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+
+WORKDIR $PROJECT_PATH
+COPY . $PROJECT_PATH/
+RUN dep ensure && \
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -ldflags="-s -w" -o build/datadog-sidekiq
+
+FROM scratch
+
+ENV PROJECT_PATH="/go/src/github.com/feedforce/datadog-sidekiq"
+
+COPY --from=builder $PROJECT_PATH/build/datadog-sidekiq /
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+ENTRYPOINT ["./datadog-sidekiq"]


### PR DESCRIPTION
## Why?

To use datadog-sidekiq in Kubernetes.

## How

* Add `Dockerfile`
* Create Docker repository in DockerHub
    * https://hub.docker.com/r/feedforce/datadog-sidekiq
* Configure Automated Build in DockerHub

    ![image](https://user-images.githubusercontent.com/10208211/55943661-f6a42580-5c81-11e9-8151-30c5274c21e7.png)

## How to check operation

```
$ docker build -t datadog-sidekiq .
$ docker run -it datadog-sidekiq -version
datadog-sidekiq version: v0.0.5
```