### PR TITLE
Add -tags option

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
+.env
+.envrc
 /.git
 /.gitignore
 Dockerfile

--- a/README.md
+++ b/README.md
@@ -43,18 +43,14 @@ $ crontab -l
 
 ### Local development
 
-Recommend using [dogstatsd-local](https://github.com/jonmorehouse/dogstatsd-local).
-
 ```
-$ make deps
-$ docker run --rm -d -p 8125:8125/udp --name dogstatsd-local jonmorehouse/dogstatsd-local
-$ docker run --rm -d -p 6379:6379 redis:alpine
-$ go run main.go
-$ docker logs dogstatsd-local
-2018/04/26 03:15:29 listening over UDP at  0.0.0.0:8125
-sidekiq.retries:0.000000|g
-sidekiq.dead:0.000000|g
-sidekiq.schedule:0.000000|g
+$ docker-compose up -d
+$ docker-compose logs dogstatsd
+Attaching to datadog-sidekiq_dogstatsd_1
+dogstatsd_1        | 2019/04/12 02:55:17 listening over UDP at  0.0.0.0:8125
+dogstatsd_1        | sidekiq.dead:0.000000|g|#tag1:value1,tag2,value2
+dogstatsd_1        | sidekiq.retries:0.000000|g|#tag1:value1,tag2,value2
+dogstatsd_1        | sidekiq.schedule:0.000000|g|#tag1:value1,tag2,value2
 ```
 
 ### Release

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ $ crontab -l
 | `-redis-namespace` | Redis namespace for Sidekiq | |
 | `-redis-password` | Redis password | |
 | `-statsd-host` | DogStatsD host | 127.0.0.1:8125 |
+| `-tags` | Add custom metric tags for Datadog. Specify in \"key:value\" format. Separate by comma to specify multiple tags | |
 | `-version` | Show datadog-sidekiq version | false |
 
 ## Development

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3"
+services:
+  datadog-sidekiq:
+    build: .
+    command: -redis-host redis:6379 -statsd-host dogstatsd:8125 -tags tag1:value1,tag2,value2
+    depends_on:
+      - dogstatsd
+      - redis
+
+  dogstatsd:
+    image: jonmorehouse/dogstatsd-local
+
+  redis:
+    image: redis:alpine

--- a/main.go
+++ b/main.go
@@ -62,6 +62,7 @@ func main() {
 	redisHost := flag.String("redis-host", "127.0.0.1:6379", "Redis host")
 	redisPassword := flag.String("redis-password", "", "Redis password")
 	redisDB := flag.Int("redis-db", 0, "Redis DB")
+	tags := flag.String("tags", "", "Add custom metric tags for Datadog. Specify in \"key:value\" format. Separate by comma to specify multiple tags")
 	flag.Parse()
 
 	if *isShowVersion {
@@ -87,8 +88,10 @@ func main() {
 		log.Fatal(err)
 	}
 
+	separatedTags := strings.Split(*tags, ",")
+
 	for k, v := range metrics {
-		if err = statsdClient.Gauge(k, v, nil, 1); err != nil {
+		if err = statsdClient.Gauge(k, v, separatedTags, 1); err != nil {
 			log.Fatal(err)
 		}
 	}


### PR DESCRIPTION
## Why?

To add custom metric tags for Datadog.

## How

* Add `-tags` option
* Update README
* (chore) Use docker-compose to improve local development
* (chore) Add `.env`, `.envrc` to `.dockerignore`

## How to check operation

```
$ docker-compose up -d
$ docker-compose logs dogstatsd
Attaching to datadog-sidekiq_dogstatsd_1
dogstatsd_1        | 2019/04/12 02:55:17 listening over UDP at  0.0.0.0:8125
dogstatsd_1        | sidekiq.dead:0.000000|g|#tag1:value1,tag2,value2
dogstatsd_1        | sidekiq.retries:0.000000|g|#tag1:value1,tag2,value2
dogstatsd_1        | sidekiq.schedule:0.000000|g|#tag1:value1,tag2,value2
```

Match the format of the DogStatsD protocol!

> ```
> metric.name:value|type|@sample_rate|#tag1:value,tag2
> ```
>
> https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/#datagram-format