### PR TITLE
Add metric enqueued

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ func fetchMetrics(c *redis.Client, namespace string) (map[string]float64, error)
 			return nil, err
 		}
 		metrics["queue."+queue] = float64(enqueued)
+		metrics["enqueued"] += float64(enqueued)
 	}
 
 	retries, err := c.ZCard(makeRedisKey([]string{namespace, "retries"})).Result()

--- a/main.go
+++ b/main.go
@@ -26,14 +26,16 @@ func fetchMetrics(c *redis.Client, namespace string) (map[string]float64, error)
 		return nil, err
 	}
 
+	var enqueuedSum float64
 	for _, queue := range queues {
 		enqueued, err := c.LLen(makeRedisKey([]string{namespace, "queue", queue})).Result()
 		if err != nil {
 			return nil, err
 		}
 		metrics["queue."+queue] = float64(enqueued)
-		metrics["enqueued"] += float64(enqueued)
+		enqueuedSum += float64(enqueued)
 	}
+	metrics["enqueued"] = float64(enqueuedSum)
 
 	retries, err := c.ZCard(makeRedisKey([]string{namespace, "retries"})).Result()
 	if err != nil {


### PR DESCRIPTION
Datadog 側で `sidekiq.queue.${キュー名}` を合計することで得られるものの、アプリケーション側の改修によりキューが増減したとき、Datadog側のモニタリング設定などの追い掛けが煩雑になるため、 `sidekiq.enqueued` がほしい。

Sidekiq ダッシュボードの Enqueued, 待機状態 のことです。

<img width="1316" alt="スクリーンショット 2021-08-20 21 53 19" src="https://user-images.githubusercontent.com/294304/130236258-3d13f327-f26c-4518-9ebe-32c307d821b6.png">