### PR TITLE
Migrate Docker Hub to GitHub packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@
 name: Create and publish a Docker image
 
 on:
-  push:
-    branches: ['release']
+  release:
+    types: [published]
 
 env:
   REGISTRY: ghcr.io
@@ -22,22 +22,16 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v1
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
       - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v2
         with:
-          context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+# see https://docs.github.com/en/actions/guides/publishing-docker-images#publishing-images-to-github-packages
+
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches: ['release']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Send Sidekiq metrics to Datadog via DogStatsD.
 
 [![GitHub release](https://img.shields.io/github/release/feedforce/datadog-sidekiq.svg?style=flat-square)](https://github.com/feedforce/datadog-sidekiq/releases)
 [![MIT license](https://img.shields.io/github/license/feedforce/datadog-sidekiq.svg?style=flat-square)](https://github.com/feedforce/datadog-sidekiq/blob/main/LICENSE)
-[![Docker Automated build](https://img.shields.io/docker/cloud/automated/feedforce/datadog-sidekiq.svg?color=blue&style=flat-square)](https://hub.docker.com/r/feedforce/datadog-sidekiq)
 
 ## Installation
 
@@ -13,7 +12,7 @@ Grab the latest binary from the GitHub [releases](https://github.com/feedforce/d
 or run with Docker.
 
 ```
-$ docker run -it feedforce/datadog-sidekiq
+$ docker run -it ghcr.io/feedforce/datadog-sidekiq
 ```
 
 ## Usage


### PR DESCRIPTION
Docker Hub の Automated Build が無料プランでは利用できなくなったため、何らかの対応が必要。

Docker Hub のアカウント管理が面倒なため、GitHub Packages を使うことにする。

ちなみに GitHub Packages で Docker イメージを公開するには二種類の方法があるが、docker.pkg.github.com は deprecated なので ghcr.io を使う。
(docker.pkg.github.com だとパブリックリポジトリでも認証が必須という違いもある)

* docker.pkg.github.com ([Dockerレジストリ](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-docker-registry))
* ghcr.io ([コンテナレジストリ](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry))

また、GitHub Packages への docker push は GitHub Actions を使うことにした。
GitHub Actions はパブリックリポジトリであれば無料で利用できるため。

> <img width="1446" alt="image" src="https://user-images.githubusercontent.com/10208211/130543122-b62636b8-8580-426d-bb0a-fb0bbdec8445.png">
>
> https://github.com/pricing

## 想定するリリースフロー

README.md に書いてあるリリースフローに沿って実施すると goreleaser によって GitHub Releases が作られる。

そのタイミングで GitHub Actions がトリガーされるように設定している。

その後 GitHub Actions によって Docker イメージがビルド & プッシュされる。

## やったこと

* GitHub Actions の workflow を設定
* README を修正
* Docker Hub のリポジトリの README にアーカイブする旨 👇 を追記

> **Important**
> 
> This repository (Docker Hub) is archived. This repository will be deleted eventually. 
> 
> Please use GitHub Packages.
> 
> [Package datadog-sidekiq](https://github.com/feedforce/datadog-sidekiq/pkgs/container/datadog-sidekiq)
> 
> ```
> $ docker pull ghcr.io/feedforce/datadog-sidekiq:latest
> ```
>
> https://hub.docker.com/repository/docker/feedforce/datadog-sidekiq/general

## やらなかったこと

goreleaser にも docker build & push の機能があったが、`Dockerfile` の内容が goreleaser 前提となってしまって開発環境で使いづらいため採用しなかった。

[Docker - GoReleaser](https://goreleaser.com/customization/docker/)