### PR TITLE
Add "queue latency" as a new metric

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ func calculateQueueLatency(contents string) float64 {
 
 	var job map[string]interface{}
 	if err := json.Unmarshal([]byte(contents), &job); err != nil {
+		log.Println(err)
 		return 0
 	}
 

--- a/main.go
+++ b/main.go
@@ -26,14 +26,14 @@ func calculateQueueLatency(contents string) float64 {
 		return 0
 	}
 
-	var job map[string]float64
+	var job map[string]interface{}
 	if err := json.Unmarshal([]byte(contents), &job); err != nil {
 		return 0
 	}
 
 	if enqueuedAt, exists := job["enqueued_at"]; exists {
-		latency := time.Now().Unix() - int64(enqueuedAt)
-		return float64(latency)
+		latency := float64(time.Now().UnixNano())/1000000.0 - enqueuedAt.(float64)
+		return latency
 	}
 
 	return 0

--- a/main.go
+++ b/main.go
@@ -51,11 +51,12 @@ func fetchMetrics(ctx context.Context, c *redis.Client, namespace string) (map[s
 	var enqueuedSum float64
 	for _, queue := range queues {
 		contents, err := c.LIndex(ctx, makeRedisKey([]string{namespace, "queue", queue}), -1).Result()
-		if err != nil {
-			return nil, err
+		if err == nil {
+			latency := calculateQueueLatency(contents)
+			metrics["latency."+queue] = latency
+		} else {
+			metrics["latency."+queue] = 0.0
 		}
-		latency := calculateQueueLatency(contents)
-		metrics["latency."+queue] = latency
 
 		enqueued, err := c.LLen(ctx, makeRedisKey([]string{namespace, "queue", queue})).Result()
 		if err != nil {


### PR DESCRIPTION
Sidekiq には [queue latency](https://www.rubydoc.info/github/mperham/sidekiq/Sidekiq%2FQueue:latency) という指標があり、これは queue における最も古いジョブが enqueue から現在までに何秒経過しているかを示しています。私は k8s で sidekiq の worker pod を立ち上げて運用していますが、 HPA の指標として queue latency を利用するのが有用であると考えています。

この PR では Datadog へ送信するメトリクスに queue latency を追加します。実装内容は以下に示す sidekiq gem の `#latency` メソッドを参考に go 言語へ置き換えたものになっています。

```rb
def latency
  entry = [Sidekiq](https://www.rubydoc.info/github/mperham/sidekiq/Sidekiq).redis { |conn|
    conn.lindex(@rname, -1)
  }
  return 0 unless entry
  job = [Sidekiq](https://www.rubydoc.info/github/mperham/sidekiq/Sidekiq).load_json(entry)
  now = Time.now.to_f
  thence = job["enqueued_at"] || now
  now - thence
end
```