### PR TITLE
Fix the calculation for the queue latency

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func calculateQueueLatency(contents string) float64 {
 	}
 
 	if enqueuedAt, exists := job["enqueued_at"]; exists {
-		latency := float64(time.Now().UnixNano())/1000000000.0 - enqueuedAt.(float64)
+		latency := float64(time.Now().UnixMicro())/1000000.0 - enqueuedAt.(float64)
 		return latency
 	}
 

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func calculateQueueLatency(contents string) float64 {
 	}
 
 	if enqueuedAt, exists := job["enqueued_at"]; exists {
-		latency := float64(time.Now().UnixNano())/1000000.0 - enqueuedAt.(float64)
+		latency := float64(time.Now().UnixNano())/1000000000.0 - enqueuedAt.(float64)
 		return latency
 	}
 

--- a/main.go
+++ b/main.go
@@ -143,4 +143,5 @@ func main() {
 			log.Fatal(err)
 		}
 	}
+	statsdClient.Flush()
 }


### PR DESCRIPTION
#27 で対応した実装に不備があったので修正しました。

- latency の計算時に「ナノ秒」から「秒」への変換で扱う指数の桁数が誤っていた
    - 67c66f440fb9660d3bd8abbe458ad300577247b3 にてマイクロ秒で計算するように変更
- DataDog へのメトリクスの送信が非同期になったので、処理の最後に `Flush()` を実行する必要がある
    - Refs: https://docs.datadoghq.com/ja/metrics/custom_metrics/dogstatsd_metrics_submission/#gauge