### PR TITLE
Support Sidekiq 8.0.x

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,0 +1,23 @@
+name: go-test
+
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+      - main
+  pull_request:
+
+jobs:
+  go-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Install dependencies
+        run: go get .
+      - name: Test with the Go CLI
+        run: go test -v

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   datadog-sidekiq:
     build: .

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,7 +7,7 @@ services:
       - redis
 
   dogstatsd:
-    image: jonmorehouse/dogstatsd-local
+    image: drish/dogstatsd-local
 
   redis:
     image: redis:alpine

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 var testCases = []struct {
 	input  []string
@@ -24,4 +27,37 @@ func TestMakeRedisKey(t *testing.T) {
 			t.Errorf("Expect %q, Actual %q (input: %q)", expect, actual, testCase.input)
 		}
 	}
+}
+
+func TestCalculateQueueLatency(t *testing.T) {
+	timeNow = func() time.Time { return time.Date(2025, 1, 1, 0, 1, 0, 123000000, time.UTC) }
+	expect := 60.0
+
+	t.Run("When passed Sidekiq 8.0 timestamp format", func(t *testing.T) {
+		jobParams := `
+        {
+            "retry": false,
+            "queue": "default",
+            "created_at": 1735689600123,
+            "enqueued_at": 1735689600123
+        }` // enqueued_at 2025-01-01 00:00:00.123
+		actual := calculateQueueLatency(jobParams)
+		if expect != actual {
+			t.Errorf("Expect %f, Actual %f (input: %q)", expect, actual, jobParams)
+		}
+	})
+
+	t.Run("When passed timestamp format before Sidekiq 8.0", func(t *testing.T) {
+		jobParams := `
+        {
+            "retry": false,
+            "queue": "default",
+            "created_at": 1735689600.123,
+            "enqueued_at": 1735689600.123
+        }` // enqueued_at 2025-01-01 00:00:00.123
+		actual := calculateQueueLatency(jobParams)
+		if expect != actual {
+			t.Errorf("Expect %f, Actual %f (input :%q)", expect, actual, jobParams)
+		}
+	})
 }


### PR DESCRIPTION
## Why

For Sidekiq 8.0.x, `enqueued_at` have been changed from epoch floats seconds to epoch milliseconds.
Since the queue latency calculation assumes epoch floats seconds, I would like to fix it.

See: https://github.com/sidekiq/sidekiq/blob/main/Changes.md#800

> WARNING The created_at, enqueued_at, failed_at and retried_at attributes are now stored as epoch milliseconds, rather than epoch floats. This is meant to avoid precision issues with JSON and JavaScript's 53-bit Floats. Example: "created_at" => 1234567890.123456 -> "created_at" => 1234567890123.

## How

When converting JSON to an `interface{}` using `json.Unmarshal`, all numbers are converted to `float64`, making it impossible to distinguish between integer and float.

See: [json package - encoding/json - Go Packages](https://pkg.go.dev/encoding/json#Unmarshal)

> To unmarshal JSON into an interface value, Unmarshal stores one of these in the interface value:
> - bool, for JSON booleans
> - float64, for JSON numbers
> - string, for JSON strings
> - []any, for JSON arrays
> - map[string]any, for JSON objects
> - nil for JSON null

To handle this, it creates a struct that treats `enqueued_at` as an integer. If the JSON can be successfully unmarshaled into this struct, it will be considered epoch milliseconds; otherwise, it will be treated as epoch float seconds.

For example

```go
type Payload struct {
	EnqueuedAt int64 `json:"enqueued_at"`
}

func main() {
	jsonString := `{"enqueued_at":1234567890.123456}`

	var payload Payload
	err := json.Unmarshal([]byte(jsonString), &payload)
	if err != nil {
		fmt.Println(err) // json: cannot unmarshal number 1234567890.123456 into Go struct field Payload.enqueued_at of type int64

	} else {
		fmt.Println(payload.EnqueuedAt)
	}

	jsonString = `{"enqueued_at":1234567890123}`
	err = json.Unmarshal([]byte(jsonString), &payload)
	if err != nil {
		fmt.Println(err)
	} else {
		fmt.Println(payload.EnqueuedAt) // 1234567890123

	}
}
```

A similar implementation has also been made on Sidekiq.
https://github.com/sidekiq/sidekiq/blob/v8.0.0/lib/sidekiq/api.rb#L280-L289

### Other improvements

- Allowed mocking the current time to test calculateQueueLatency.
- Added test execution in CI.
- Updated the Docker Compose file to the new format.
- Use `drish/dogstatsd-local `instead of `jonmorehouse/dogstatsd-local` becouse it is deleted from Docker Hub
