### PR TITLE
Add `-redis-tls`, `redis-tls-insecure` CLI option to support TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ $ crontab -l
 | `-redis-host` | Redis host | 127.0.0.1:6379 |
 | `-redis-namespace` | Redis namespace for Sidekiq | |
 | `-redis-password` | Redis password | |
+| `-redis-tls` | Use TLS for Redis connection | false |
+| `-redis-tls-insecure` | Skip TLS verification for Redis connection (use with caution) | false |
 | `-statsd-host` | DogStatsD host | 127.0.0.1:8125 |
 | `-tags` | Add custom metric tags for Datadog. Specify in \"key:value\" format. Separate by comma to specify multiple tags | |
 | `-version` | Show datadog-sidekiq version | false |

--- a/main.go
+++ b/main.go
@@ -143,7 +143,10 @@ func main() {
 	if *redisTLS {
 		tlsConfig = &tls.Config{}
 	}
-	if tlsConfig != nil && *redisTLSInsecure {
+	if *redisTLSInsecure {
+		if !*redisTLS {
+			log.Fatal("-redis-tls-insecure can only be used with -redis-tls")
+		}
 		tlsConfig.InsecureSkipVerify = true
 	}
 

--- a/main.go
+++ b/main.go
@@ -143,7 +143,7 @@ func main() {
 	if *redisTLS {
 		tlsConfig = &tls.Config{}
 	}
-	if *redisTLSInsecure {
+	if tlsConfig != nil && *redisTLSInsecure {
 		tlsConfig.InsecureSkipVerify = true
 	}
 

--- a/main.go
+++ b/main.go
@@ -130,6 +130,7 @@ func main() {
 	redisPassword := flag.String("redis-password", "", "Redis password")
 	redisDB := flag.Int("redis-db", 0, "Redis DB")
 	redisTLS := flag.Bool("redis-tls", false, "Use TLS for Redis connection")
+	redisTLSInsecure := flag.Bool("redis-tls-insecure", false, "Skip TLS verification for Redis connection (use with caution)")
 	tags := flag.String("tags", "", "Add custom metric tags for Datadog. Specify in \"key:value\" format. Separate by comma to specify multiple tags")
 	flag.Parse()
 
@@ -141,6 +142,9 @@ func main() {
 	var tlsConfig *tls.Config
 	if *redisTLS {
 		tlsConfig = &tls.Config{}
+	}
+	if *redisTLSInsecure {
+		tlsConfig.InsecureSkipVerify = true
 	}
 
 	statsdClient, err := statsd.New(*statsdHost)

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -128,12 +129,18 @@ func main() {
 	redisHost := flag.String("redis-host", "127.0.0.1:6379", "Redis host")
 	redisPassword := flag.String("redis-password", "", "Redis password")
 	redisDB := flag.Int("redis-db", 0, "Redis DB")
+	redisTLS := flag.Bool("redis-tls", false, "Use TLS for Redis connection")
 	tags := flag.String("tags", "", "Add custom metric tags for Datadog. Specify in \"key:value\" format. Separate by comma to specify multiple tags")
 	flag.Parse()
 
 	if *isShowVersion {
 		fmt.Printf("datadog-sidekiq version: %s\n", version)
 		return
+	}
+
+	var tlsConfig *tls.Config
+	if *redisTLS {
+		tlsConfig = &tls.Config{}
 	}
 
 	statsdClient, err := statsd.New(*statsdHost)
@@ -144,9 +151,10 @@ func main() {
 	statsdClient.Namespace = "sidekiq."
 
 	redisClient := redis.NewClient(&redis.Options{
-		Addr:     *redisHost,
-		Password: *redisPassword,
-		DB:       *redisDB,
+		Addr:      *redisHost,
+		Password:  *redisPassword,
+		DB:        *redisDB,
+		TLSConfig: tlsConfig,
 	})
 
 	var ctx = context.Background()


### PR DESCRIPTION
Redis への TLS 接続をサポートするための `-redis-tls` CLI オプションを追加します。
また、主にローカル環境での動作確認用に証明書の検証をスキップする `-redis-tls-insecure` CLI オプションも追加します。
(`-redis-tls` を使わずに `-redis-tls-insecure` のみを使うとエラー終了する)

## 動作確認

ElastiCache など、何らかの TLS が有効な Redis を用意し、ポートフォワードなどで接続できる状態にして検証。

```
$ go run main.go -redis-host 127.0.0.1:63790 -redis-db 2 -redis-tls
2025/08/06 17:00:32 tls: failed to verify certificate: x509: cannot validate certificate for 127.0.0.1 because it doesn't contain any IP SANs
exit status 1

$ go run main.go -redis-host 127.0.0.1:63790 -redis-db 2 -redis-tls -redis-tls-insecure
$ echo $status
0
```

`-redis-tls` を使わない場合にエラーが出ないことも確認。

```
$ go run main.go -redis-host 127.0.0.1:63790 -redis-db 2 
$ echo $status
0
```

`-redis-tls-insecure` のみを指定した場合はエラー終了することも確認。

```
$ go run main.go -redis-host 127.0.0.1:63790 -redis-db 2 -redis-tls-insecure
2025/08/07 11:50:01 -redis-tls-insecure can only be used with -redis-tls
exit status 1
```

TLS 未対応の Redis 接続時はエラーが出ることも確認。

```
$ docker compose run --rm datadog-sidekiq -redis-host redis:6379 -statsd-host dogstatsd:8125 -tags tag1:value1,tag2:value2 --redis-tls
2025/08/07 02:54:12 context deadline exceeded
```