### PR TITLE
Add `-redis-user` CLI option to support Redis username

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ $ crontab -l
 | `-redis-db` | Redis DB | 0 |
 | `-redis-host` | Redis host | 127.0.0.1:6379 |
 | `-redis-namespace` | Redis namespace for Sidekiq | |
+| `-redis-user` | Redis username | |
 | `-redis-password` | Redis password | |
 | `-redis-tls` | Use TLS for Redis connection | false |
 | `-redis-tls-insecure` | Skip TLS verification for Redis connection (use with caution) | false |

--- a/main.go
+++ b/main.go
@@ -127,6 +127,7 @@ func main() {
 	statsdHost := flag.String("statsd-host", "127.0.0.1:8125", "DogStatsD host")
 	redisNamespace := flag.String("redis-namespace", "", "Redis namespace for Sidekiq")
 	redisHost := flag.String("redis-host", "127.0.0.1:6379", "Redis host")
+	redisUser := flag.String("redis-user", "", "Redis username")
 	redisPassword := flag.String("redis-password", "", "Redis password")
 	redisDB := flag.Int("redis-db", 0, "Redis DB")
 	redisTLS := flag.Bool("redis-tls", false, "Use TLS for Redis connection")
@@ -159,6 +160,7 @@ func main() {
 
 	redisClient := redis.NewClient(&redis.Options{
 		Addr:      *redisHost,
+		Username:  *redisUser,
 		Password:  *redisPassword,
 		DB:        *redisDB,
 		TLSConfig: tlsConfig,


### PR DESCRIPTION
Redis へのパスワード認証をするための `-redis-user` CLI オプションを追加します。
(`-redis-password` オプションはすでにある)

## 動作確認

Redis へのパスワード認証が成功すること。

```
$ go run main.go -redis-host 127.0.0.1:63790 -redis-user $REDIS_USER -redis-password $REDIS_PASSWORD -redis-db 2 -redis-tls -redis-tls-insecure
$ echo $status
0
```

`-redis-user`, `-redis-password` なしでも正常に動作すること。

```
$ go run main.go -redis-host 127.0.0.1:63790 -redis-db 2 -redis-tls -redis-tls-insecure
$ echo $status
0
```