### PR TITLE
Fix golangci-lint failure by updating Go version to 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/socialplusjp/datadog-sidekiq
 
-go 1.17
+go 1.18
 
 require (
 	github.com/DataDog/datadog-go v4.8.3+incompatible


### PR DESCRIPTION
> [!NOTE]
> Generated by claude-code

## Why?

golangci-lint 2.11.2 uses the `-buildvcs` flag internally, which was introduced in Go 1.18.
Since `go.mod` specified `go 1.17`, `actions/setup-go` set up Go 1.17 and CI failed with:

```
flag provided but not defined: -buildvcs
```

## How?

Updated the `go` directive in `go.mod` from `1.17` to `1.18`.