### PR TITLE
fix: update Dockerfile and README to reflect Go 1.18 requirement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17-alpine as builder
+FROM golang:1.18-alpine as builder
 
 RUN apk add ca-certificates git
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $ crontab -l
 ### Requirements
 
 * Docker
-* Go `>= 1.17.0`
+* Go `>= 1.18.0`
 
 ### Local development
 


### PR DESCRIPTION
> [!NOTE]
> Generated by claude-code

## Why?

PR #46 bumped the `go` directive in `go.mod` to 1.18, but the Dockerfile builder image and README requirements were not updated accordingly.
This was flagged in a Copilot code review.

## How?

- Updated `Dockerfile` builder image from `golang:1.17-alpine` to `golang:1.18-alpine`
- Updated minimum Go version requirement in `README.md` from `>= 1.17.0` to `>= 1.18.0`